### PR TITLE
Add clock hand components to SwatchClock

### DIFF
--- a/src/components/ClockHand.vue
+++ b/src/components/ClockHand.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { DateTime } from 'luxon';
+import { calculateSwatch } from '@/util';
+
+const props = defineProps<{
+  time: DateTime;
+}>();
+
+const rotation = computed(() => (Math.floor(calculateSwatch(props.time)) / 1000) * 360);
+</script>
+
+<template>
+  <use xlink:href="#clock-hand" :transform="'rotate(' + rotation + ')'" />
+</template>
+
+<style scoped></style>

--- a/src/components/SecondHand.vue
+++ b/src/components/SecondHand.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+import type { DateTime } from 'luxon';
+import { computed } from 'vue';
+import { calculateSwatch } from '@/util';
+
+const props = defineProps<{
+  time: DateTime;
+}>();
+
+const rotation = computed(() => (calculateSwatch(props.time) % 1) * 360);
+</script>
+
+<template>
+  <use xlink:href="#second-hand" :transform="'rotate(' + rotation + ')'" />
+</template>
+
+<style scoped></style>

--- a/src/components/SwatchClock.vue
+++ b/src/components/SwatchClock.vue
@@ -2,6 +2,8 @@
 import { computed, ref } from 'vue';
 import type { DateTime } from 'luxon';
 import { calculateSwatch } from '@/util';
+import ClockHand from '@/components/ClockHand.vue';
+import SecondHand from '@/components/SecondHand.vue';
 
 const markers = ref<number[]>(
   Array(1000)
@@ -19,17 +21,28 @@ const { VITE_BUILD_SHA: version } = import.meta.env;
 <template>
   <svg viewBox="-500 -500 1000 1000">
     <defs>
-      <path id="marker" d="M 0,-490 l 5,0 0,40 -5,0 z" />
+      <path id="marker" d="M -2.5,-490 l 5,0 0,40 -5,0 z" />
+      <g id="clock-hand">
+        <path d="M -5,30 l 10,0 0,-505 -10,0 z" fill="red" />
+        <circle cx="0" cy="0" r="15" fill="red" />
+      </g>
+      <path id="second-hand" d="M -1,45 l 2,0 0,-510 -2,0 z" fill="black" />
     </defs>
-    <text class="time" x="0" y="250" text-anchor="middle">{{ swatchTime }}</text>
-    <text class="version" x="0" y="300" text-anchor="middle">{{ version }}</text>
-    <g id="markers">
+    <g>
+      <text class="time" x="0" y="250" text-anchor="middle">{{ swatchTime }}</text>
+      <text class="version" x="0" y="300" text-anchor="middle">{{ version }}</text>
+    </g>
+    <g>
       <use
         xlink:href="#marker"
         v-for="marker in markers"
         :key="marker"
         :transform="'rotate(' + marker + ')'"
       />
+    </g>
+    <g>
+      <ClockHand :time="time" />
+      <SecondHand :time="time" />
     </g>
   </svg>
 </template>


### PR DESCRIPTION
Introduced `ClockHand` and `SecondHand` components to modularize the rendering of clock hands in the `SwatchClock` component. Updated the SVG structure and marker definitions to integrate these components. This enhances maintainability and simplifies further customizations.